### PR TITLE
[Feature]-Basic crud for managing volunteer skills

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,7 @@ PGUSER=postgres
 PGPASSWORD=masterkey
 
 # Alternativa: cadena única
-DATABASE_URL=postgres://postgres:masterkey@localhost:5432/voluntaliaest
+DATABASE_URL=postgres://postgres:masterkey@localhost:5432/voluntalia-test
 # PGHOST=db
 # PGPORT=5432
 # PGDATABASE=voluntalia-test

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ const notificationRoutes = require('./routes/notification');
 const documentRoutes = require('./routes/documents');
 const activityRoutes = require('./routes/activity');
 const workLogRoutes = require('./routes/worklog');
+const skillRoutes = require('./routes/skill');
 
 const app = express();
 
@@ -26,6 +27,7 @@ app.use('/notification', notificationRoutes);
 app.use('/document', documentRoutes);
 app.use('/activity', activityRoutes);
 app.use('/worklog', workLogRoutes);
+app.use('/skill', skillRoutes);
 
 app.use(errorHandler); // * Middleware to manage errors 
 

--- a/src/controllers/skillController.js
+++ b/src/controllers/skillController.js
@@ -1,0 +1,81 @@
+const skillService = require('../services/skillService');
+
+exports.create = async (req, res, next) => {
+    try {
+        const { name } = req.body;
+        const sub = req.user.sub;
+        if (!name) return res.status(400).json({ error: "name is required" });
+        const skill = await skillService.create(name, sub);
+        res.status(201).json({skill});
+    } catch (err) {
+        next(err);
+    }
+}
+
+exports.getAllSkills = async (req, res, next) => {
+    try {
+        const skills = await skillService.getAll();
+        res.status(201).json({skills});
+    } catch (err) {
+        next(err);
+    }
+}
+
+// ! Coordinator-only: update an existing skill
+exports.update = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const { name } = req.body;
+
+    await skillService.update(name, id);
+    res.status(201).json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ! Coordinator-only: delete skill
+exports.deleteSkill = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+
+    await skillService.deleteSkill(id);
+    res.status(201).json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ! Coordinator-only: assign a volunteer to a skill
+exports.assignSkill = async (req, res, next) => {
+  try {
+    const { id } = req.params; // skill id
+    const { volunteer_id } = req.body;
+
+    // ! Validate required field
+    if (!volunteer_id)
+      return res.status(400).json({ error: "volunteer_id required" });
+
+    await skillService.assignSkill(id, volunteer_id);
+    res.status(201).json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// ! Coordinator-only: remove a volunteer from a skill
+exports.unassignSkill = async (req, res, next) => {
+  try {
+    const { id } = req.params; // activity id
+    const { volunteer_id } = req.body;
+
+    // ! Validate required field
+    if (!volunteer_id)
+      return res.status(400).json({ error: "volunteer_id required" });
+
+    await skillService.unassignSkill(id, volunteer_id);
+    res.status(201).json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,5 +1,5 @@
 const { UniqueConstraintError, ValidationError } = require('sequelize');
-const ConflictError = require('../errors/ErrorTypes');
+const ConflictError = require('../errors/errorTypes');
 
 module.exports = (err, _req, res, _next) => {
   let status = err.status || err.statusCode || 500;

--- a/src/migrations/20251005161101-create-skill.js
+++ b/src/migrations/20251005161101-create-skill.js
@@ -1,0 +1,30 @@
+'use strict';
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('skills', {
+      id: {
+        type: Sequelize.UUID,
+        primaryKey: true,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+      },
+      name: {
+        type: Sequelize.STRING
+      },
+      created_by: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+    });
+  },
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('skills');
+  }
+};

--- a/src/migrations/20251005161122-create-skills-volunteers.js
+++ b/src/migrations/20251005161122-create-skills-volunteers.js
@@ -1,0 +1,36 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, DataTypes) => {
+    await queryInterface.createTable('skills_volunteers', {
+      volunteer_id: {
+        type: DataTypes.UUID,
+        references: {
+          model: 'users',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+        primaryKey: true,
+        allowNull: false
+      },
+      skill_id: {
+        type: DataTypes.UUID,
+        references: {
+          model: 'skills',
+          key: 'id',
+        },
+        onDelete: 'CASCADE',
+        primaryKey: true,
+        allowNull: false
+      },
+      assigned_at: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.literal('NOW()'),
+      },
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('skills_volunteers');
+  },
+};

--- a/src/models/skill.js
+++ b/src/models/skill.js
@@ -1,0 +1,43 @@
+'use strict';
+const { Model } = require('sequelize');
+
+module.exports = (sequelize, DataTypes) => {
+  class Skill extends Model {
+    static associate(models) {
+      // N-N con User  (a través de user_skills)
+      Skill.belongsToMany(models.User, {
+        as: 'volunteers',
+        through: 'skills_volunteers',
+        foreignKey: 'skill_id',
+        otherKey: 'volunteer_id',
+        timestamps: false,
+      });
+    }
+  }
+
+  Skill.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        primaryKey: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+      },
+      created_by: { type: DataTypes.UUID, allowNull: false },
+      created_at: { type: DataTypes.DATE, allowNull: true },
+    },
+    {
+      sequelize,
+      modelName: 'Skill',
+      tableName: 'skills',
+      underscored: true,
+      timestamps: false,
+    }
+  );
+
+  return Skill;
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,5 +1,7 @@
 'use strict';
-const { Model } = require('sequelize');
+const {
+  Model
+} = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     /**
@@ -22,6 +24,14 @@ module.exports = (sequelize, DataTypes) => {
         otherKey: 'activity_id',
         timestamps: false,
       });
+
+      User.belongsToMany(models.Skill, {
+        as: 'skills',
+        through: 'skills_users',
+        foreignKey: 'user_id',
+        otherKey: 'skill_id',
+        timestamps: false,
+      });
     }
   }
   User.init(
@@ -39,11 +49,7 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         defaultValue: 'VOLUNTEER',
       },
-      is_active: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-        defaultValue: true,
-      },
+      is_active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
       phone: {
         type: DataTypes.STRING,
         allowNull: true,

--- a/src/routes/skill.js
+++ b/src/routes/skill.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const { requireAuth, authorizeRoles } = require('../middleware/auth');
+const { create, getAllSkills, update, deleteSkill, assignSkill, unassignSkill } = require('../controllers/skillController');
+//, getAllActivities, update, deleteActivity, assignActivity, getVolunteersByActivity, unassignActivity
+const roles = require('../constants/roles');
+
+const router = express.Router();
+
+router.post('/create', requireAuth, authorizeRoles(roles.COORDINATOR), create);
+
+router.get('/', getAllSkills);
+
+router.put('/update/:id', requireAuth, authorizeRoles(roles.COORDINATOR), update);
+
+router.delete('/delete/:id', requireAuth, authorizeRoles(roles.COORDINATOR), deleteSkill);
+
+router.post('/:id/assign', requireAuth, authorizeRoles(roles.COORDINATOR),assignSkill);
+
+router.post('/:id/unassign', requireAuth, authorizeRoles(roles.COORDINATOR),unassignSkill);
+
+module.exports = router;

--- a/src/seeders/20251005161500-demo-skills.js
+++ b/src/seeders/20251005161500-demo-skills.js
@@ -1,0 +1,21 @@
+'use strict';
+const { Skill } = require('../models');
+
+module.exports = {
+  async up () {
+    const anaId   = '11111111-1111-1111-1111-111111111111';
+    const carlosId = '22222222-2222-2222-2222-222222222222';
+    const demoLogs = [
+      { name: "Frontend", created_by: anaId },
+      { name: "Backend", created_by: anaId },
+      { name: "Microservicios", created_by: carlosId },
+      { name: "Ngrx", created_by: carlosId },
+    ];
+
+    await Skill.bulkCreate(demoLogs, { returning: false });
+  },
+
+  async down () {
+    await Skill.destroy({ truncate: true, cascade: true });
+  }
+};

--- a/src/services/activityService.js
+++ b/src/services/activityService.js
@@ -1,3 +1,4 @@
+const { NotFoundError } = require("../errors/errorTypes");
 const { Activity, User } = require("../models");
 
 // * Create a new activity (coordinator only)
@@ -40,13 +41,14 @@ exports.deleteActivity = async (id) => {
 // ! Assign a single volunteer to an activity (replaces any existing)
 exports.assignActivity = async (id, volunteer_id) => {
   const activity = await Activity.findByPk(id);
+  if (!activity) throw new NotFoundError("Activity not found");
   await activity.setVolunteers([volunteer_id]);
 };
 
 // ! Remove a specific volunteer from an activity
 exports.unassignActivity = async (id, volunteer_id) => {
   const activity = await Activity.findByPk(id);
-  if (!activity) throw new Error("Activity not found");
+  if (!activity) throw new NotFoundError("Activity not found");
 
   await activity.removeVolunteer(volunteer_id);
 };

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -5,7 +5,7 @@ const {
   ConflictError,
   CredentialError,
   NotFoundError,
-} = require('../errors/ErrorTypes');
+} = require('../errors/errorTypes');
 const {
   signAccessToken,
   signRefreshToken,

--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -1,4 +1,4 @@
-const { NotFoundError } = require("../errors/ErrorTypes");
+const { NotFoundError } = require("../errors/errorTypes");
 const path = require("path");
 const fs = require("fs");
 const { Document } = require("../models");

--- a/src/services/notificationService.js
+++ b/src/services/notificationService.js
@@ -1,5 +1,5 @@
 const roles = require('../constants/roles');
-const { NotFoundError } = require('../errors/ErrorTypes');
+const { NotFoundError } = require('../errors/errorTypes');
 const { User, Notification } = require('../models');
 
 exports.sendAllVolunteer = async (senderId, message) => {

--- a/src/services/skillService.js
+++ b/src/services/skillService.js
@@ -1,0 +1,39 @@
+const { Skill } = require('../models');
+
+// * Create a new skill (coordinator only)
+exports.create = async (name, sub) => {
+    return await Skill.create({name, created_by: sub});
+};
+
+// * Fetch all skills
+exports.getAll = async() => {
+    return await Skill.findAll({
+      attributes: ['id', 'name', 'created_by'],
+      order: [['created_at', 'DESC']],
+    });
+};
+
+// ? Update skill details by ID
+exports.update = async (name, id) => {
+  await Skill.update({ name }, { where: { id } });
+};
+
+// ! Delete a skill by ID
+exports.deleteSkill = async (id) => {
+  await Skill.destroy({ where: { id } });
+};
+
+// ! Assign a single volunteer to a skill (replaces any existing)
+exports.assignSkill = async (id, volunteer_id) => {
+  const skill = await Skill.findByPk(id);
+  if (!skill) throw new Error("Skill not found");
+  await skill.setVolunteers([volunteer_id]);
+};
+
+// ! Remove a specific volunteer from a skill
+exports.unassignSkill = async (id, volunteer_id) => {
+  const skill = await Skill.findByPk(id);
+  if (!skill) throw new NotFoundError("Activity not found");
+
+  await skill.removeVolunteer(volunteer_id);
+};


### PR DESCRIPTION
# Skills CRUD & Volunteer Assignment Endpoints

## What’s new  
- Full CRUD for `Skill` entity (create, read, update, delete).  
- REST endpoints ready for assigning / un-assigning skills to volunteers.  

### Skill management
| Method | Path | Description |
|--------|------|-------------|
| GET | `/skill` | List all skills  |
| POST | `/skill/create` | Create new skill |
| PUT | `/skill/update/:id` | Update skill |
| DELETE | `/skill/delete/:id` | Soft-delete skill |