### PR TITLE
feat: Show volunteers by Activity

### DIFF
--- a/src/routes/activity.js
+++ b/src/routes/activity.js
@@ -1,6 +1,14 @@
 const express = require('express');
 const { requireAuth, authorizeRoles } = require('../middleware/auth');
-const { create, getAllActivities, update, deleteActivity, assignActivity, getVolunteersByActivity, unassignActivity } = require('../controllers/activityController');
+const {
+  create,
+  getAllActivities,
+  update,
+  deleteActivity,
+  assignActivity,
+  getVolunteersByActivity,
+  unassignActivity,
+} = require('../controllers/activityController');
 const roles = require('../constants/roles');
 
 const router = express.Router();
@@ -15,13 +23,28 @@ router.get('/', requireAuth, getAllActivities);
 router.put('/:id', requireAuth, authorizeRoles(roles.COORDINATOR), update);
 
 // ! Coordinator-only: delete an activity
-router.delete('/:id', requireAuth, authorizeRoles(roles.COORDINATOR), deleteActivity);
+router.delete(
+  '/:id',
+  requireAuth,
+  authorizeRoles(roles.COORDINATOR),
+  deleteActivity
+);
 
 // ! Coordinator-only: assign a volunteer to an activity
-router.post('/:id/assign', requireAuth, authorizeRoles(roles.COORDINATOR), assignActivity);
+router.post(
+  '/:id/assign',
+  requireAuth,
+  authorizeRoles(roles.COORDINATOR),
+  assignActivity
+);
 
 // ! Coordinator-only: remove a volunteer from an activity
-router.post('/:id/unassign', requireAuth, authorizeRoles(roles.COORDINATOR), unassignActivity);
+router.post(
+  '/:id/unassign',
+  requireAuth,
+  authorizeRoles(roles.COORDINATOR),
+  unassignActivity
+);
 
 // * List all volunteers for a specific activity
 router.get('/:id/volunteers', requireAuth, getVolunteersByActivity);


### PR DESCRIPTION
# Description
On the Activities page we want to display the volunteers by each activity

# Solution
On the Activities payload I've added `total_volunteers` and `volunteers` array 

GET `http://localhost:4000/activity`
```
{
            "id": "becb68f8-bd9a-4f6d-bc61-3b8907f9aa86",
            "title": "Clases de apoyo escolar",
            "description": "Refuerzo escolar en matemáticas para niños de primaria.",
            "date": "2024-09-09",
            "created_name": "Ana García",
            "total_volunteers": 2,
            "volunteers": [
                {
                    "id": "d935225e-26b2-4c2b-a097-a7e1fd273cd4",
                    "name": "Lucía Fernández",
                    "email": "lucia@mail.com"
                },
                {
                    "id": "755f1ce8-9dce-4ce4-b175-6d076e84b289",
                    "name": "Julio González",
                    "email": "juliojose.gonzalez@gmail.com"
                }
            ]
        },
```


