### PR TITLE
feat: add created_at to the me endpoint

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,7 +1,5 @@
 'use strict';
-const {
-  Model
-} = require('sequelize');
+const { Model } = require('sequelize');
 module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     /**
@@ -54,7 +52,11 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         defaultValue: 'VOLUNTEER',
       },
-      is_active: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: true },
+      is_active: {
+        type: DataTypes.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+      },
       phone: {
         type: DataTypes.STRING,
         allowNull: true,
@@ -77,7 +79,7 @@ module.exports = (sequelize, DataTypes) => {
       modelName: 'User',
       tableName: 'users',
       underscored: true,
-      timestamps: false,
+      timestamps: true,
     }
   );
   return User;


### PR DESCRIPTION
# Description

Enable timestamp fields in User model to expose creation and modification dates in API responses, particularly for the /me endpoint.

# API Response Changes
`/auth/me endpoint`

## Before
```
{
  "user": {
    "id": "123e4567-e89b-12d3-a456-426614174000",
    "name": "John Doe",
    "email": "john@example.com",
    "role": "VOLUNTEER"
  }
}
```

## After  
```
{
  "user": {
    "id": "123e4567-e89b-12d3-a456-426614174000",
    "name": "John Doe", 
    "email": "john@example.com",
    "role": "VOLUNTEER",
    "createdAt": "2024-01-15T10:30:00.000Z",
    "updatedAt": "2024-01-20T14:22:00.000Z"
  }
}
```